### PR TITLE
Feat: VS Code запуск одного testcase

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
@@ -51,7 +51,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
 
       - name: Create .npmrc for github registry auth
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish prerelease
         run: |
-          yarn lerna publish --yes --canary --force-publish
+          yarn lerna publish --yes --canary --force-publish --no-verify-access
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         if: github.ref == 'refs/heads/canary'
@@ -45,7 +45,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
 
       - name: Publish release to npm
-        run: yarn lerna publish from-package --yes
+        run: yarn lerna publish from-package --yes --no-verify-access
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         if: github.ref == 'refs/heads/master'

--- a/modules/nightwatch/src/upgrades/vscode-tasks.js
+++ b/modules/nightwatch/src/upgrades/vscode-tasks.js
@@ -23,8 +23,30 @@ function updateVsCodeTasks() {
             },
             {
               type: 'shell',
+              label: 'Nightwatch: запустить testcase текущего файла в Chrome локально',
+              command:
+                "yarn et nightwatch:run --browser local_chrome --test='${file}' --testcase='${input:testcase}'",
+              problemMatcher: [],
+              presentation: {
+                showReuseMessage: false,
+              },
+              group: 'build',
+            },
+            {
+              type: 'shell',
               label: 'Nightwatch: запустить текущий файл в Chrome на удалённом сервере',
               command: "yarn et nightwatch:run --browser remote_chrome --test='${file}'",
+              problemMatcher: [],
+              presentation: {
+                showReuseMessage: false,
+              },
+              group: 'build',
+            },
+            {
+              type: 'shell',
+              label: 'Nightwatch: запустить testcase текущего файла в Chrome на удалённом сервере',
+              command:
+                "yarn et nightwatch:run --browser remote_chrome --test='${file}' --testcase='${input:testcase}'",
               problemMatcher: [],
               presentation: {
                 showReuseMessage: false,
@@ -58,6 +80,17 @@ function updateVsCodeTasks() {
             },
           ],
           (task) => task.label
+        ),
+        inputs: uniqBy(
+          [
+            ...config.inputs,
+            {
+              id: 'testcase',
+              type: 'promptString',
+              description: 'Имя запускаемого testcase',
+            },
+          ],
+          (input) => input.id
         ),
       }
     },

--- a/modules/nightwatch/src/upgrades/vscode-tasks.js
+++ b/modules/nightwatch/src/upgrades/vscode-tasks.js
@@ -83,7 +83,7 @@ function updateVsCodeTasks() {
         ),
         inputs: uniqBy(
           [
-            ...config.inputs,
+            ...(config.inputs || []),
             {
               id: 'testcase',
               type: 'promptString',


### PR DESCRIPTION
Добавлены команды для запуска одного testcase в файле

Nightwatch: запустить testcase текущего файла в Chrome локально
Nightwatch: запустить testcase текущего файла в Chrome на удалённом сервере